### PR TITLE
add market visibility restrictions

### DIFF
--- a/backend/migrations/20250422204110_add_market_visible_to.sql
+++ b/backend/migrations/20250422204110_add_market_visible_to.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS "market_visible_to" (
+  "market_id" INTEGER NOT NULL REFERENCES "market",
+  "account_id" INTEGER NOT NULL REFERENCES "account",
+  PRIMARY KEY ("market_id", "account_id")
+) WITHOUT ROWID;
+CREATE INDEX IF NOT EXISTS "idx_market_visible_to_account_id" ON "market_visible_to" ("account_id");

--- a/backend/src/convert.rs
+++ b/backend/src/convert.rs
@@ -66,6 +66,7 @@ impl From<db::MarketWithRedeemables> for websocket_api::Market {
                     redeem_fee,
                 },
             redeemables,
+            visible_to,
         }: db::MarketWithRedeemables,
     ) -> Self {
         Self {
@@ -93,6 +94,7 @@ impl From<db::MarketWithRedeemables> for websocket_api::Market {
             ),
             redeemable_for: redeemables.into_iter().map(Redeemable::from).collect(),
             redeem_fee: redeem_fee.0.try_into().unwrap(),
+            visible_to: visible_to,
         }
     }
 }

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -609,9 +609,20 @@ impl DB {
         )
         .fetch_all(&self.pool)
         .await?;
+
+        let visible_to = sqlx::query!(
+            r#"SELECT market_id, account_id FROM market_visible_to ORDER BY market_id"#
+        )
+        .fetch_all(&self.pool)
+        .await?;
         let redeemables_chunked = redeemables
             .into_iter()
             .chunk_by(|redeemable| redeemable.fund_id);
+
+        let visible_to_chunked = visible_to
+            .into_iter()
+            .chunk_by(|visibility| visibility.market_id);
+
         markets
             .into_iter()
             .merge_join_by(redeemables_chunked.into_iter(), |market, (fund_id, _)| {
@@ -622,14 +633,55 @@ impl DB {
                 let Some(market) = left else {
                     return Err(sqlx::Error::RowNotFound);
                 };
+                Ok((market, right))
+            })
+            .merge_join_by(visible_to_chunked.into_iter(), |market, (market_id, _)| {
+                if let Ok((market, _)) = market {
+                    market.id.cmp(&market_id)
+                } else {
+                    std::cmp::Ordering::Equal
+                }
+            })
+            .map(|joined| {
+                let (left, right) = joined.left_and_right();
+                let Some(Ok((market, redeemables))) = left else {
+                    return Err(sqlx::Error::RowNotFound);
+                };
                 Ok(MarketWithRedeemables {
                     market,
-                    redeemables: right
+                    redeemables: redeemables
                         .map(|(_, redeemables)| redeemables.collect())
+                        .unwrap_or_default(),
+                    visible_to: right
+                        .map(|(_, visibilities)| visibilities.map(|v| v.account_id).collect())
                         .unwrap_or_default(),
                 })
             })
             .collect()
+    }
+
+    #[instrument(err, skip(self))]
+    pub async fn is_market_visible_to(&self, market_id: i64, account_id: i64) -> SqlxResult<bool> {
+        // A market is visible if either:
+        // 1. It has no visibility restrictions (no entries in market_visible_to)
+        // 2. The account is explicitly listed in market_visible_to
+        let is_visible = sqlx::query_scalar!(
+            r#"
+            SELECT NOT EXISTS (
+                SELECT 1 FROM market_visible_to WHERE market_id = ?
+            ) OR EXISTS (
+                SELECT 1 FROM market_visible_to
+                WHERE market_id = ? AND account_id = ?
+            ) as "is_visible!: bool"
+            "#,
+            market_id,
+            market_id,
+            account_id
+        )
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(is_visible)
     }
 
     #[must_use]
@@ -1083,6 +1135,20 @@ impl DB {
         .fetch_one(transaction.as_mut())
         .await?;
 
+        // Insert market visibility restrictions
+        for account_id in &create_market.visible_to {
+            sqlx::query!(
+                r#"
+                    INSERT INTO market_visible_to (market_id, account_id)
+                    VALUES (?, ?)
+                "#,
+                market.id,
+                account_id
+            )
+            .execute(transaction.as_mut())
+            .await?;
+        }
+
         let mut redeemables = Vec::new();
         for redeemable in create_market.redeemable_for {
             let redeemable = sqlx::query_as!(
@@ -1105,6 +1171,7 @@ impl DB {
         Ok(Ok(MarketWithRedeemables {
             market,
             redeemables,
+            visible_to: create_market.visible_to,
         }))
     }
 
@@ -2129,6 +2196,7 @@ pub struct EnsureUserCreatedSuccess {
 pub struct MarketWithRedeemables {
     pub market: Market,
     pub redeemables: Vec<Redeemable>,
+    pub visible_to: Vec<i64>,
 }
 
 #[derive(Debug)]
@@ -2385,6 +2453,7 @@ pub enum ValidationFailure {
     InsufficientCredit,
     InvalidAmount,
     SharedOwnershipAccountHasOpenPositions,
+    VisibleToAccountNotFound,
 }
 
 impl ValidationFailure {
@@ -2430,6 +2499,7 @@ impl ValidationFailure {
             Self::SharedOwnershipAccountHasOpenPositions => {
                 "Shared ownership account has open positions"
             }
+            Self::VisibleToAccountNotFound => "One or more visible_to accounts not found",
         }
     }
 }

--- a/backend/src/handle_socket.rs
+++ b/backend/src/handle_socket.rs
@@ -226,6 +226,22 @@ async fn send_initial_public_data(
     let mut next_order = all_live_orders.try_next().await?;
 
     for market in markets {
+        if !is_admin {
+            let mut is_visible = false;
+            for &account_id in owned_accounts {
+                if db
+                    .is_market_visible_to(market.market.id, account_id)
+                    .await?
+                {
+                    is_visible = true;
+                    break;
+                }
+            }
+            if !is_visible && !market.visible_to.is_empty() {
+                continue;
+            }
+        }
+
         let market = Market::from(market);
         let market_id = market.id;
         let market_msg = encode_server_message(String::new(), SM::Market(market));

--- a/frontend/src/lib/components/forms/createMarket.svelte
+++ b/frontend/src/lib/components/forms/createMarket.svelte
@@ -11,7 +11,8 @@
 		name: '',
 		description: '',
 		minSettlement: 0,
-		maxSettlement: 0
+		maxSettlement: 0,
+		visibleTo: []
 	});
 	let open = $state(false);
 

--- a/python-client/src/metagame/trading_client.py
+++ b/python-client/src/metagame/trading_client.py
@@ -134,6 +134,7 @@ class TradingClient:
         redeemable_for: List[websocket_api.Redeemable] = [],
         redeem_fee: float = 0.0,
         hide_account_ids: bool = False,
+        visible_to: List[int] = [],
     ) -> websocket_api.Market:
         """
         Create a new market on the exchange.
@@ -147,6 +148,7 @@ class TradingClient:
                 redeemable_for=redeemable_for,
                 redeem_fee=redeem_fee,
                 hide_account_ids=hide_account_ids,
+                visible_to=visible_to,
             ),
         )
         response = self.request(msg)

--- a/python-client/src/metagame/websocket_api.py
+++ b/python-client/src/metagame/websocket_api.py
@@ -57,6 +57,7 @@ class Market(betterproto.Message):
     max_settlement: float = betterproto.double_field(7)
     redeemable_for: List["Redeemable"] = betterproto.message_field(4)
     redeem_fee: float = betterproto.double_field(11)
+    visible_to: List[int] = betterproto.int64_field(14)
     open: "MarketOpen" = betterproto.message_field(8, group="status")
     closed: "MarketClosed" = betterproto.message_field(9, group="status")
 
@@ -283,6 +284,7 @@ class CreateMarket(betterproto.Message):
     redeemable_for: List["Redeemable"] = betterproto.message_field(5)
     redeem_fee: float = betterproto.double_field(6)
     hide_account_ids: bool = betterproto.bool_field(7)
+    visible_to: List[int] = betterproto.int64_field(8)
 
 
 @dataclass

--- a/schema-js/index.d.ts
+++ b/schema-js/index.d.ts
@@ -1180,6 +1180,9 @@ export namespace websocket_api {
         /** Market redeemFee */
         redeemFee?: (number|null);
 
+        /** Market visibleTo */
+        visibleTo?: ((number|Long)[]|null);
+
         /** Market open */
         open?: (websocket_api.Market.IOpen|null);
 
@@ -1225,6 +1228,9 @@ export namespace websocket_api {
 
         /** Market redeemFee. */
         public redeemFee: number;
+
+        /** Market visibleTo. */
+        public visibleTo: (number|Long)[];
 
         /** Market open. */
         public open?: (websocket_api.Market.IOpen|null);
@@ -4627,6 +4633,9 @@ export namespace websocket_api {
 
         /** CreateMarket hideAccountIds */
         hideAccountIds?: (boolean|null);
+
+        /** CreateMarket visibleTo */
+        visibleTo?: ((number|Long)[]|null);
     }
 
     /** Represents a CreateMarket. */
@@ -4658,6 +4667,9 @@ export namespace websocket_api {
 
         /** CreateMarket hideAccountIds. */
         public hideAccountIds: boolean;
+
+        /** CreateMarket visibleTo. */
+        public visibleTo: (number|Long)[];
 
         /**
          * Creates a new CreateMarket instance using the specified properties.

--- a/schema-js/index.js
+++ b/schema-js/index.js
@@ -3113,6 +3113,7 @@ $root.websocket_api = (function() {
          * @property {number|null} [maxSettlement] Market maxSettlement
          * @property {Array.<websocket_api.IRedeemable>|null} [redeemableFor] Market redeemableFor
          * @property {number|null} [redeemFee] Market redeemFee
+         * @property {Array.<number|Long>|null} [visibleTo] Market visibleTo
          * @property {websocket_api.Market.IOpen|null} [open] Market open
          * @property {websocket_api.Market.IClosed|null} [closed] Market closed
          */
@@ -3127,6 +3128,7 @@ $root.websocket_api = (function() {
          */
         function Market(properties) {
             this.redeemableFor = [];
+            this.visibleTo = [];
             if (properties)
                 for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null)
@@ -3214,6 +3216,14 @@ $root.websocket_api = (function() {
         Market.prototype.redeemFee = 0;
 
         /**
+         * Market visibleTo.
+         * @member {Array.<number|Long>} visibleTo
+         * @memberof websocket_api.Market
+         * @instance
+         */
+        Market.prototype.visibleTo = $util.emptyArray;
+
+        /**
          * Market open.
          * @member {websocket_api.Market.IOpen|null|undefined} open
          * @memberof websocket_api.Market
@@ -3292,6 +3302,12 @@ $root.websocket_api = (function() {
                 writer.uint32(/* id 12, wireType 0 =*/96).int64(message.transactionId);
             if (message.transactionTimestamp != null && Object.hasOwnProperty.call(message, "transactionTimestamp"))
                 $root.google.protobuf.Timestamp.encode(message.transactionTimestamp, writer.uint32(/* id 13, wireType 2 =*/106).fork()).ldelim();
+            if (message.visibleTo != null && message.visibleTo.length) {
+                writer.uint32(/* id 14, wireType 2 =*/114).fork();
+                for (var i = 0; i < message.visibleTo.length; ++i)
+                    writer.int64(message.visibleTo[i]);
+                writer.ldelim();
+            }
             return writer;
         };
 
@@ -3366,6 +3382,17 @@ $root.websocket_api = (function() {
                     }
                 case 11: {
                         message.redeemFee = reader.double();
+                        break;
+                    }
+                case 14: {
+                        if (!(message.visibleTo && message.visibleTo.length))
+                            message.visibleTo = [];
+                        if ((tag & 7) === 2) {
+                            var end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.visibleTo.push(reader.int64());
+                        } else
+                            message.visibleTo.push(reader.int64());
                         break;
                     }
                 case 8: {
@@ -3450,6 +3477,13 @@ $root.websocket_api = (function() {
             if (message.redeemFee != null && message.hasOwnProperty("redeemFee"))
                 if (typeof message.redeemFee !== "number")
                     return "redeemFee: number expected";
+            if (message.visibleTo != null && message.hasOwnProperty("visibleTo")) {
+                if (!Array.isArray(message.visibleTo))
+                    return "visibleTo: array expected";
+                for (var i = 0; i < message.visibleTo.length; ++i)
+                    if (!$util.isInteger(message.visibleTo[i]) && !(message.visibleTo[i] && $util.isInteger(message.visibleTo[i].low) && $util.isInteger(message.visibleTo[i].high)))
+                        return "visibleTo: integer|Long[] expected";
+            }
             if (message.open != null && message.hasOwnProperty("open")) {
                 properties.status = 1;
                 {
@@ -3535,6 +3569,20 @@ $root.websocket_api = (function() {
             }
             if (object.redeemFee != null)
                 message.redeemFee = Number(object.redeemFee);
+            if (object.visibleTo) {
+                if (!Array.isArray(object.visibleTo))
+                    throw TypeError(".websocket_api.Market.visibleTo: array expected");
+                message.visibleTo = [];
+                for (var i = 0; i < object.visibleTo.length; ++i)
+                    if ($util.Long)
+                        (message.visibleTo[i] = $util.Long.fromValue(object.visibleTo[i])).unsigned = false;
+                    else if (typeof object.visibleTo[i] === "string")
+                        message.visibleTo[i] = parseInt(object.visibleTo[i], 10);
+                    else if (typeof object.visibleTo[i] === "number")
+                        message.visibleTo[i] = object.visibleTo[i];
+                    else if (typeof object.visibleTo[i] === "object")
+                        message.visibleTo[i] = new $util.LongBits(object.visibleTo[i].low >>> 0, object.visibleTo[i].high >>> 0).toNumber();
+            }
             if (object.open != null) {
                 if (typeof object.open !== "object")
                     throw TypeError(".websocket_api.Market.open: object expected");
@@ -3561,8 +3609,10 @@ $root.websocket_api = (function() {
             if (!options)
                 options = {};
             var object = {};
-            if (options.arrays || options.defaults)
+            if (options.arrays || options.defaults) {
                 object.redeemableFor = [];
+                object.visibleTo = [];
+            }
             if (options.defaults) {
                 if ($util.Long) {
                     var long = new $util.Long(0, 0, false);
@@ -3628,6 +3678,14 @@ $root.websocket_api = (function() {
                     object.transactionId = options.longs === String ? $util.Long.prototype.toString.call(message.transactionId) : options.longs === Number ? new $util.LongBits(message.transactionId.low >>> 0, message.transactionId.high >>> 0).toNumber() : message.transactionId;
             if (message.transactionTimestamp != null && message.hasOwnProperty("transactionTimestamp"))
                 object.transactionTimestamp = $root.google.protobuf.Timestamp.toObject(message.transactionTimestamp, options);
+            if (message.visibleTo && message.visibleTo.length) {
+                object.visibleTo = [];
+                for (var j = 0; j < message.visibleTo.length; ++j)
+                    if (typeof message.visibleTo[j] === "number")
+                        object.visibleTo[j] = options.longs === String ? String(message.visibleTo[j]) : message.visibleTo[j];
+                    else
+                        object.visibleTo[j] = options.longs === String ? $util.Long.prototype.toString.call(message.visibleTo[j]) : options.longs === Number ? new $util.LongBits(message.visibleTo[j].low >>> 0, message.visibleTo[j].high >>> 0).toNumber() : message.visibleTo[j];
+            }
             return object;
         };
 
@@ -12425,6 +12483,7 @@ $root.websocket_api = (function() {
          * @property {Array.<websocket_api.IRedeemable>|null} [redeemableFor] CreateMarket redeemableFor
          * @property {number|null} [redeemFee] CreateMarket redeemFee
          * @property {boolean|null} [hideAccountIds] CreateMarket hideAccountIds
+         * @property {Array.<number|Long>|null} [visibleTo] CreateMarket visibleTo
          */
 
         /**
@@ -12437,6 +12496,7 @@ $root.websocket_api = (function() {
          */
         function CreateMarket(properties) {
             this.redeemableFor = [];
+            this.visibleTo = [];
             if (properties)
                 for (var keys = Object.keys(properties), i = 0; i < keys.length; ++i)
                     if (properties[keys[i]] != null)
@@ -12500,6 +12560,14 @@ $root.websocket_api = (function() {
         CreateMarket.prototype.hideAccountIds = false;
 
         /**
+         * CreateMarket visibleTo.
+         * @member {Array.<number|Long>} visibleTo
+         * @memberof websocket_api.CreateMarket
+         * @instance
+         */
+        CreateMarket.prototype.visibleTo = $util.emptyArray;
+
+        /**
          * Creates a new CreateMarket instance using the specified properties.
          * @function create
          * @memberof websocket_api.CreateMarket
@@ -12538,6 +12606,12 @@ $root.websocket_api = (function() {
                 writer.uint32(/* id 6, wireType 1 =*/49).double(message.redeemFee);
             if (message.hideAccountIds != null && Object.hasOwnProperty.call(message, "hideAccountIds"))
                 writer.uint32(/* id 7, wireType 0 =*/56).bool(message.hideAccountIds);
+            if (message.visibleTo != null && message.visibleTo.length) {
+                writer.uint32(/* id 8, wireType 2 =*/66).fork();
+                for (var i = 0; i < message.visibleTo.length; ++i)
+                    writer.int64(message.visibleTo[i]);
+                writer.ldelim();
+            }
             return writer;
         };
 
@@ -12602,6 +12676,17 @@ $root.websocket_api = (function() {
                         message.hideAccountIds = reader.bool();
                         break;
                     }
+                case 8: {
+                        if (!(message.visibleTo && message.visibleTo.length))
+                            message.visibleTo = [];
+                        if ((tag & 7) === 2) {
+                            var end2 = reader.uint32() + reader.pos;
+                            while (reader.pos < end2)
+                                message.visibleTo.push(reader.int64());
+                        } else
+                            message.visibleTo.push(reader.int64());
+                        break;
+                    }
                 default:
                     reader.skipType(tag & 7);
                     break;
@@ -12664,6 +12749,13 @@ $root.websocket_api = (function() {
             if (message.hideAccountIds != null && message.hasOwnProperty("hideAccountIds"))
                 if (typeof message.hideAccountIds !== "boolean")
                     return "hideAccountIds: boolean expected";
+            if (message.visibleTo != null && message.hasOwnProperty("visibleTo")) {
+                if (!Array.isArray(message.visibleTo))
+                    return "visibleTo: array expected";
+                for (var i = 0; i < message.visibleTo.length; ++i)
+                    if (!$util.isInteger(message.visibleTo[i]) && !(message.visibleTo[i] && $util.isInteger(message.visibleTo[i].low) && $util.isInteger(message.visibleTo[i].high)))
+                        return "visibleTo: integer|Long[] expected";
+            }
             return null;
         };
 
@@ -12701,6 +12793,20 @@ $root.websocket_api = (function() {
                 message.redeemFee = Number(object.redeemFee);
             if (object.hideAccountIds != null)
                 message.hideAccountIds = Boolean(object.hideAccountIds);
+            if (object.visibleTo) {
+                if (!Array.isArray(object.visibleTo))
+                    throw TypeError(".websocket_api.CreateMarket.visibleTo: array expected");
+                message.visibleTo = [];
+                for (var i = 0; i < object.visibleTo.length; ++i)
+                    if ($util.Long)
+                        (message.visibleTo[i] = $util.Long.fromValue(object.visibleTo[i])).unsigned = false;
+                    else if (typeof object.visibleTo[i] === "string")
+                        message.visibleTo[i] = parseInt(object.visibleTo[i], 10);
+                    else if (typeof object.visibleTo[i] === "number")
+                        message.visibleTo[i] = object.visibleTo[i];
+                    else if (typeof object.visibleTo[i] === "object")
+                        message.visibleTo[i] = new $util.LongBits(object.visibleTo[i].low >>> 0, object.visibleTo[i].high >>> 0).toNumber();
+            }
             return message;
         };
 
@@ -12717,8 +12823,10 @@ $root.websocket_api = (function() {
             if (!options)
                 options = {};
             var object = {};
-            if (options.arrays || options.defaults)
+            if (options.arrays || options.defaults) {
                 object.redeemableFor = [];
+                object.visibleTo = [];
+            }
             if (options.defaults) {
                 object.name = "";
                 object.description = "";
@@ -12744,6 +12852,14 @@ $root.websocket_api = (function() {
                 object.redeemFee = options.json && !isFinite(message.redeemFee) ? String(message.redeemFee) : message.redeemFee;
             if (message.hideAccountIds != null && message.hasOwnProperty("hideAccountIds"))
                 object.hideAccountIds = message.hideAccountIds;
+            if (message.visibleTo && message.visibleTo.length) {
+                object.visibleTo = [];
+                for (var j = 0; j < message.visibleTo.length; ++j)
+                    if (typeof message.visibleTo[j] === "number")
+                        object.visibleTo[j] = options.longs === String ? String(message.visibleTo[j]) : message.visibleTo[j];
+                    else
+                        object.visibleTo[j] = options.longs === String ? $util.Long.prototype.toString.call(message.visibleTo[j]) : options.longs === Number ? new $util.LongBits(message.visibleTo[j].low >>> 0, message.visibleTo[j].high >>> 0).toNumber() : message.visibleTo[j];
+            }
             return object;
         };
 

--- a/schema/create-market.proto
+++ b/schema/create-market.proto
@@ -11,4 +11,5 @@ message CreateMarket {
   repeated Redeemable redeemable_for = 5;
   double redeem_fee = 6;
   bool hide_account_ids = 7;
+  repeated int64 visible_to = 8;  // List of account IDs that can see this market. If empty, visible to all.
 }

--- a/schema/market.proto
+++ b/schema/market.proto
@@ -15,6 +15,7 @@ message Market {
   double max_settlement = 7;
   repeated Redeemable redeemable_for = 4;
   double redeem_fee = 11;
+  repeated int64 visible_to = 14;  // List of account IDs that can see this market. If empty, visible to all.
 
   oneof status {
     Open open = 8;


### PR DESCRIPTION
- CreateMarket has a `visible_to` field
- if `visible_to` is empty, every one can see the market (like it is now)
- if `visible_to` has account ids in it:
   - only owners of those accounts can _see_ the market
   - you must act as an account that is in `visible_to` to _trade_ in the market
- this PR does not provide functionality for allowing people to see a market with no way to trade on it (if you can see the market, there is always some account that you can switch to to trade on the market)